### PR TITLE
feat: add skeleton placeholders and min size variables

### DIFF
--- a/lib/ap-activity-item.js
+++ b/lib/ap-activity-item.js
@@ -14,9 +14,11 @@ export class ActivityPubActivityItem extends ActivityPubElement {
     'Announce': ActivityPubAnnounceActivity
   }
 
-  static styles = css`
+  static styles = [super.styles, css`
     :host {
         display: block;
+        min-width: var(--ap-min-width);
+        min-height: var(--ap-min-height);
     }
     div.activity {
         border: 1px solid lightgray;
@@ -24,7 +26,12 @@ export class ActivityPubActivityItem extends ActivityPubElement {
         padding: 8px;
         margin: 8px 0;
     }
-  `;
+    .skeleton {
+        min-width: var(--ap-min-width);
+        min-height: var(--ap-min-height);
+        background-color: lightgray;
+    }
+  `];
 
   render() {
     if (this._error) {
@@ -36,7 +43,7 @@ export class ActivityPubActivityItem extends ActivityPubElement {
     } else if (!this.json) {
       return html`
       <div class="activity">
-        <p>Loading...</p>
+        <div class="skeleton"></div>
       </div>
     `;
     } else {

--- a/lib/ap-actor-item.js
+++ b/lib/ap-actor-item.js
@@ -4,9 +4,11 @@ import DOMPurify from 'https://cdn.jsdelivr.net/npm/dompurify@3.2.3/+esm';
 
 export class ActivityPubActorItem extends ActivityPubElement {
 
-  static styles = css`
+  static styles = [super.styles, css`
     :host {
       display: block;
+      min-width: var(--ap-min-width);
+      min-height: var(--ap-min-height);
     }
     .icon {
       float: left;
@@ -18,7 +20,12 @@ export class ActivityPubActorItem extends ActivityPubElement {
         padding: 8px;
         margin: 8px 0;
     }
-  `
+    .skeleton {
+        min-width: var(--ap-min-width);
+        min-height: var(--ap-min-height);
+        background-color: lightgray;
+    }
+  `]
 
   constructor() {
     super();
@@ -34,7 +41,7 @@ export class ActivityPubActorItem extends ActivityPubElement {
     } else if (!this.json) {
       return html`
       <div class="actor">
-        <p>Loading...</p>
+        <div class="skeleton"></div>
       </div>
     `;
     } else {

--- a/lib/ap-actor-profile.js
+++ b/lib/ap-actor-profile.js
@@ -20,6 +20,8 @@ export class ActivityPubActorProfile extends LitElement {
   static styles = css`
     :host {
       display: block;
+      min-width: var(--ap-min-width);
+      min-height: var(--ap-min-height);
     }
     .icon {
       float: left;

--- a/lib/ap-announce-activity.js
+++ b/lib/ap-announce-activity.js
@@ -14,11 +14,21 @@ export class ActivityPubAnnounceActivity extends ActivityPubElement {
     super();
   }
 
-  static styles = css`
+  static styles = [super.styles, css`
+  :host {
+    display: block;
+    min-width: var(--ap-min-width);
+    min-height: var(--ap-min-height);
+  }
   .announce-activity {
     display: block;
   }
-  `
+  .skeleton {
+    min-width: var(--ap-min-width);
+    min-height: var(--ap-min-height);
+    background-color: lightgray;
+  }
+  `]
 
   static activityTypes = [
     'Accept',
@@ -65,13 +75,13 @@ export class ActivityPubAnnounceActivity extends ActivityPubElement {
     } else if (!this.json) {
       return html`
       <div class="announce-activity">
-        <p>Loading...</p>
+        <div class="skeleton"></div>
       </div>
     `;
     } else if (!this._object) {
       return html`
       <div class="announce-activity">
-        <p>Loading object...</p>
+        <div class="skeleton"></div>
       </div>
       `
     } else {

--- a/lib/ap-article.js
+++ b/lib/ap-article.js
@@ -4,11 +4,18 @@ import { ActivityPubElement } from './ap-element.js';
 
 export class ActivityPubArticle extends ActivityPubElement {
 
-  static styles = css`
+  static styles = [super.styles, css`
   :host {
     display: block;
+    min-width: var(--ap-min-width);
+    min-height: var(--ap-min-height);
   }
-  `;
+  .skeleton {
+    min-width: var(--ap-min-width);
+    min-height: var(--ap-min-height);
+    background-color: lightgray;
+  }
+  `];
 
   constructor() {
     super();
@@ -24,7 +31,7 @@ export class ActivityPubArticle extends ActivityPubElement {
     } else if (!this.json) {
       return html`
       <div class="article">
-        <p>Loading...</p>
+        <div class="skeleton"></div>
       </div>
     `;
     } else {

--- a/lib/ap-collection.js
+++ b/lib/ap-collection.js
@@ -17,9 +17,11 @@ export class ActivityPubCollectionElement extends ActivityPubElement {
     }
   }
 
-  static styles = css`
+  static styles = [super.styles, css`
     :host {
       display: block;
+      min-width: var(--ap-min-width);
+      min-height: var(--ap-min-height);
     }
     ol.items {
       list-style: none;
@@ -32,7 +34,7 @@ export class ActivityPubCollectionElement extends ActivityPubElement {
     ol.items::marker {
       display: none;
     }
-  `;
+  `];
 
   constructor() {
     super();

--- a/lib/ap-element.js
+++ b/lib/ap-element.js
@@ -1,4 +1,4 @@
-import { LitElement } from 'https://cdn.jsdelivr.net/gh/lit/dist@3/core/lit-core.min.js';
+import { LitElement, css } from 'https://cdn.jsdelivr.net/gh/lit/dist@3/core/lit-core.min.js';
 
 const AS2_NS = 'https://www.w3.org/ns/activitystreams#';
 const AS2_PREFIX = 'as:';
@@ -10,6 +10,13 @@ function asMatch(obj, type) {
 }
 
 export class ActivityPubElement extends LitElement {
+
+  static styles = css`
+    :host {
+      --ap-min-height: 48px;
+      --ap-min-width: 48px;
+    }
+  `;
 
   // Override fetchFunction to use a different fetch implementation
   // For example, to use a custom fetch function that adds authentication headers

--- a/lib/ap-note.js
+++ b/lib/ap-note.js
@@ -11,15 +11,22 @@ export class ActivityPubNote extends ActivityPubElement {
     }
   }
 
-  static styles = css`
+  static styles = [super.styles, css`
     :host {
       display: block;
+      min-width: var(--ap-min-width);
+      min-height: var(--ap-min-height);
     }
     .icon {
       float: left;
       margin-right: 8px;
     }
-    `;
+    .skeleton {
+      min-width: var(--ap-min-width);
+      min-height: var(--ap-min-height);
+      background-color: lightgray;
+    }
+    `];
 
   constructor() {
     super();
@@ -36,13 +43,13 @@ export class ActivityPubNote extends ActivityPubElement {
     } else if (!this.json) {
       return html`
       <div class="note">
-        <p>Loading...</p>
+        <div class="skeleton"></div>
       </div>
       `
     } else if (!this._attributedTo) {
       return html`
       <div class="note">
-        <p>Loading author...</p>
+        <div class="skeleton"></div>
       </div>
       `
     } else {

--- a/lib/ap-object.js
+++ b/lib/ap-object.js
@@ -5,11 +5,18 @@ import { ActivityPubArticle } from './ap-article.js';
 
 export class ActivityPubObject extends ActivityPubElement {
 
-  static styles = css`
+  static styles = [super.styles, css`
   :host {
     display: block;
+    min-width: var(--ap-min-width);
+    min-height: var(--ap-min-height);
   }
-  `;
+  .skeleton {
+    min-width: var(--ap-min-width);
+    min-height: var(--ap-min-height);
+    background-color: lightgray;
+  }
+  `];
 
   constructor() {
     super();
@@ -30,7 +37,7 @@ export class ActivityPubObject extends ActivityPubElement {
     } else if (!this.json) {
       return html`
       <div class="object">
-        <p>Loading...</p>
+        <div class="skeleton"></div>
       </div>
       `;
     } else {

--- a/lib/avatar-icon.js
+++ b/lib/avatar-icon.js
@@ -15,6 +15,8 @@ export class AvatarIcon extends LitElement {
   static styles = css`
   :host {
     display: inline-block;
+    min-width: var(--ap-min-width);
+    min-height: var(--ap-min-height);
   }
   .avatar {
       background-color: lightgray;


### PR DESCRIPTION
## Summary
- introduce `--ap-min-height` and `--ap-min-width` CSS vars in `ActivityPubElement`
- apply min-size vars and skeleton loading UI to ActivityPub components
- ensure skeleton placeholders match configurable minimum dimensions

## Testing
- `npm test` *(fails: The CHROME_PATH environment variable must be set to a Chrome/Chromium executable)*

------
https://chatgpt.com/codex/tasks/task_e_689cbe0ca974832f9af62c0fc1c519f3